### PR TITLE
Add try_consume_until_current_head

### DIFF
--- a/include/rigtorp/MPMCQueue.h
+++ b/include/rigtorp/MPMCQueue.h
@@ -253,6 +253,36 @@ public:
     }
   }
 
+  template <typename Consumer> bool try_consume_until_current_head(Consumer &&c) noexcept {
+#ifdef __cpp_lib_is_invocable
+    static_assert(std::is_nothrow_invocable_v<Consumer, T &&>,
+                  "Consumer must be noexcept invocable with T&&");
+#endif
+    bool consumedSomething = false;
+    const auto head = head_.load(std::memory_order_acquire);
+    auto tail = tail_.load(std::memory_order_acquire);
+    while (tail < head) {
+      auto &slot = slots_[idx(tail)];
+      if (turn(tail) * 2 + 1 == slot.turn.load(std::memory_order_acquire)) {
+        if (tail_.compare_exchange_strong(tail, tail + 1)) {
+          static_assert(noexcept(c(slot.move())),
+                        "Consumer must be noexcept invocable with T&&");
+          c(slot.move());
+          slot.destroy();
+          slot.turn.store(turn(tail) * 2 + 2, std::memory_order_release);
+          consumedSomething = true;
+        }
+      } else {
+        auto const prevTail = tail;
+        tail = tail_.load(std::memory_order_acquire);
+        if (tail == prevTail) {
+          return consumedSomething;
+        }
+      }
+    }
+    return consumedSomething;
+  }
+
 private:
   constexpr size_t idx(size_t i) const noexcept { return i % capacity_; }
 

--- a/src/MPMCQueueTest.cpp
+++ b/src/MPMCQueueTest.cpp
@@ -135,6 +135,20 @@ int main(int argc, char *argv[]) {
   }
 
   {
+    int counter = 0;
+    auto consumer = [&counter](int i) noexcept { counter += i; };
+
+    MPMCQueue<int> q(16);
+    assert(q.try_consume_until_current_head(consumer) == false);
+    q.push(1);
+    q.push(2);
+    q.push(3);
+    assert(q.try_consume_until_current_head(consumer) == true);
+    assert(counter == 6);
+    assert(q.try_consume_until_current_head(consumer) == false);
+  }
+
+  {
     bool throws = false;
     try {
       MPMCQueue<int> q(0);


### PR DESCRIPTION
Inspired by your try_consume PR I added a `try_consume_until_current_head` method that consumes all elements of the queue that were added before the current head.

My use case is a macro recorder. The queue captures commands from different threads. Then, when the user triggers the macro, all recorded commands are executed. However it's possible that while the commands belonging to the first recording are still being consumed, commands from a second recording are already being recorded, and they shouldn't be executed until next time the macro is triggered. With `try_consume` or `try_pop` I cannot guarantee this.

I'm not sure what the memory ordering should be for the `head_.load` at the beginning of the function. Can you help here?

I'm not sure what's you policy on new features, let me know if you think this doesn't belong to the project.