### PR TITLE
Add size() and empty() methods

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,10 +23,9 @@ jobs:
         
   build-windows:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     strategy:
       matrix:
-        os: [windows-latest, windows-2016]
         config: [Debug, Release]
         standard: [11, 17]
     

--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ t2.join();
   Try to dequeue an item by copying or moving the item into
   `v`. Return `true` on sucess and `false` if the queue is empty.
 
+- `ssize_t size();`
+
+  Returns the number of elements in the queue.
+
+  The size can be negative when the queue is empty and there is at least one
+  reader waiting. Since this is a concurrent queue the size is only a best
+  effort guess until all reader and writer threads have been joined.
+
+- `bool empty();`
+
+  Returns true if the queue is empty.
+
+  Since this is a concurrent queue this is only a best effort guess until all
+  reader and writer threads have been joined.
+
 All operations except construction and destruction are thread safe.
 
 ## Implementation
@@ -138,6 +153,7 @@ implementation:
 - [ ] Use C++20 concepts instead of `static_assert` if available
 - [X] Use `std::hardware_destructive_interference_size` if available
 - [ ] Add API for zero-copy deqeue and batch dequeue operations
+- [ ] Add `[[nodiscard]]` attributes
 
 ## About
 

--- a/include/rigtorp/MPMCQueue.h
+++ b/include/rigtorp/MPMCQueue.h
@@ -40,7 +40,7 @@ SOFTWARE.
 
 namespace rigtorp {
 namespace mpmc {
-#ifdef __cpp_lib_hardware_interference_size
+#if defined(__cpp_lib_hardware_interference_size) && !defined(__APPLE__)
 static constexpr size_t hardwareInterferenceSize =
     std::hardware_destructive_interference_size;
 #else

--- a/src/MPMCQueueTest.cpp
+++ b/src/MPMCQueueTest.cpp
@@ -74,17 +74,21 @@ int main(int argc, char *argv[]) {
 
   {
     MPMCQueue<TestType> q(11);
+    assert(q.size() == 0 && q.empty());
     for (int i = 0; i < 10; i++) {
       q.emplace();
     }
+    assert(q.size() == 10 && !q.empty());
     assert(TestType::constructed.size() == 10);
 
     TestType t;
     q.pop(t);
+    assert(q.size() == 9 && !q.empty());
     assert(TestType::constructed.size() == 10);
 
     q.pop(t);
     q.emplace();
+    assert(q.size() == 9 && !q.empty());
     assert(TestType::constructed.size() == 10);
   }
   assert(TestType::constructed.size() == 0);
@@ -93,9 +97,13 @@ int main(int argc, char *argv[]) {
     MPMCQueue<int> q(1);
     int t = 0;
     assert(q.try_push(1) == true);
+    assert(q.size() == 1 && !q.empty());
     assert(q.try_push(2) == false);
+    assert(q.size() == 1 && !q.empty());
     assert(q.try_pop(t) == true && t == 1);
+    assert(q.size() == 0 && q.empty());
     assert(q.try_pop(t) == false && t == 1);
+    assert(q.size() == 0 && q.empty());
   }
 
   // Copyable only type


### PR DESCRIPTION
Since read and write sequence can wraparound on 32bit, the size can be
incorrect there. Not sure how to deal with that yet.

Closes #29