### PR TITLE
Replace std::aligned_storage with alignas(T) std::array<Byte, sizeof(T)>

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,14 +9,14 @@ jobs:
     strategy:
       matrix:
         config: [Debug, Release]
-        standard: [11, 17]
+        standard: [11, 17, 23]
 
     steps:
     - uses: actions/checkout@v1
     - name: Build & Test
       run: |
         cmake -E remove_directory build
-        cmake -B build -S . -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_CXX_STANDARD=${{ matrix.standard }} -DCMAKE_CXX_FLAGS="-Werror -fsanitize=address,undefined"
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_CXX_STANDARD=${{ matrix.standard }} -DCMAKE_CXX_FLAGS="-Werror -fsanitize=address,undefined -Wno-interference-size"
         cmake --build build
         cd build
         ctest --output-on-failure
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         config: [Debug, Release]
-        standard: [11, 17]
+        standard: [11, 17, 23]
     
     steps:
     - uses: actions/checkout@v1
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         config: [Debug, Release]
-        standard: [11, 17]
+        standard: [11, 17, 23]
 
     steps:
     - uses: actions/checkout@v1

--- a/include/rigtorp/MPMCQueue.h
+++ b/include/rigtorp/MPMCQueue.h
@@ -22,6 +22,7 @@ SOFTWARE.
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <cstddef> // offsetof
@@ -81,6 +82,11 @@ template <typename T> struct AlignedAllocator {
   }
 };
 #endif
+#if defined(__cpp_lib_byte) && !defined(__APPLE__)
+using Byte = std::byte;
+#else
+using Byte = unsigned char;
+#endif
 
 template <typename T> struct Slot {
   ~Slot() noexcept {
@@ -105,7 +111,7 @@ template <typename T> struct Slot {
 
   // Align to avoid false sharing between adjacent slots
   alignas(hardwareInterferenceSize) std::atomic<size_t> turn = {0};
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
+  alignas(T) std::array<Byte, sizeof(T)> storage;
 };
 
 template <typename T, typename Allocator = AlignedAllocator<Slot<T>>>


### PR DESCRIPTION
As described in #49, std::aligned_storage was deprecated in C++23, which causes warnings and/or build errors depending on consuming project settings.

I have tried to implement the proposed migration of using an aligned array of bytes instead.

My local tooling (g++-13) also complained that the code is using a platform specific value, without specifying the value in a compiler flag, so I added `-Wno-interference-size` to the compiler flags to silence that warning.

I'm not sure how to verify if this harms performance of the library. Any pointers or help would be appreciated on that matter.